### PR TITLE
Add dynamic glow to skills section on skill click

### DIFF
--- a/portfolio-site/css/styles.css
+++ b/portfolio-site/css/styles.css
@@ -406,9 +406,9 @@ nav {
 
 /* Skills section */
 .skills {
-    background-color: var(--body-bg);
     position: relative;
-    background-image: linear-gradient(135deg, #d9dde2 0%, #edf0f4 50%, #c8cfd8 100%);
+    background: linear-gradient(135deg, #d9dde2 0%, #edf0f4 50%, #c8cfd8 100%);
+    transition: background 0.5s ease, box-shadow 0.5s ease;
 }
 
 .skills:before {

--- a/portfolio-site/js/scripts.js
+++ b/portfolio-site/js/scripts.js
@@ -964,13 +964,25 @@ if (logoElement) {
     
     // Skill items interaction
     const skillItems = document.querySelectorAll('.skill-item');
+    const skillsSection = document.querySelector('.skills');
+    let skillHue = 0;
     skillItems.forEach(item => {
         item.addEventListener('click', function() {
             this.classList.add('active');
             playRandomKeySound();
+
+            // Cycle through hues for a subtle color change
+            skillHue = (skillHue + 30) % 360;
+            const gradient = `linear-gradient(135deg, hsl(${skillHue}, 70%, 90%) 0%, hsl(${skillHue}, 70%, 97%) 50%, hsl(${skillHue}, 70%, 85%) 100%)`;
+            skillsSection.style.background = gradient;
+            skillsSection.style.boxShadow = `0 0 20px hsla(${skillHue}, 70%, 75%, 0.8)`;
+
             setTimeout(() => {
                 this.classList.remove('active');
             }, 200);
+            setTimeout(() => {
+                skillsSection.style.boxShadow = '';
+            }, 500);
         });
     });
     


### PR DESCRIPTION
## Summary
- add CSS transition to skills section for smooth color and glow changes
- implement JS that cycles background gradients and temporary glow when skill buttons are clicked

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ebba57adc83219a29bb32bf2ac364